### PR TITLE
Fix for enormously large quick info for image source issues

### DIFF
--- a/src/QuickInfo/Image/ImageQuickInfo.cs
+++ b/src/QuickInfo/Image/ImageQuickInfo.cs
@@ -1,12 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Windows;
-using System.Windows.Controls;
-using System.Windows.Forms;
-using System.Windows.Media;
-using System.Windows.Media.Imaging;
-using Microsoft.VisualStudio.Language.Intellisense;
+﻿using Microsoft.VisualStudio.Language.Intellisense;
 using Microsoft.VisualStudio.Text;
 using Microsoft.WebTools.Languages.Css.Document;
 using Microsoft.WebTools.Languages.Css.Editor.Document;
@@ -14,6 +6,14 @@ using Microsoft.WebTools.Languages.Css.Parser;
 using Microsoft.WebTools.Languages.Css.TreeItems.Functions;
 using Microsoft.WebTools.Languages.Shared.Editor.EditorHelpers;
 using Microsoft.WebTools.Languages.Shared.Editor.Host;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Forms;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
 
 namespace CssTools
 {
@@ -138,14 +138,14 @@ namespace CssTools
             }
             catch (Exception ex)
             {
-                qiContent.Add(new Image { Source = noPreview });
+                qiContent.Add(new Image { Source = noPreview, Width = 150, Height = 150 });
                 qiContent.Add(ex.Message);
                 return;
             }
 
             if (source == null)
             {
-                qiContent.Add(new Image { Source = noPreview });
+                qiContent.Add(new Image { Source = noPreview, Width = 150, Height = 150 });
                 qiContent.Add("Couldn't locate " + url);
                 return;
             }
@@ -174,12 +174,14 @@ namespace CssTools
             var size = WebEditor.ExportProvider.GetExport<ITextBufferFactoryService>().Value.CreateTextBuffer();
             size.SetText("Loading...");
 
-			source.OnDownloaded(() => size.SetText(source.PixelWidth + "×" + source.PixelHeight));
-			if (source.IsDownloading)
+            source.OnDownloaded(() => size.SetText(source.PixelWidth + "×" + source.PixelHeight));
+            if (source.IsDownloading)
             {
                 EventHandler<System.Windows.Media.ExceptionEventArgs> failure = (s, e) =>
                 {
                     image.Source = noPreview;
+                    image.Width = 150;
+                    image.Height = 150;
                     size.SetText("Couldn't load image: " + e.ErrorException.Message);
                 };
                 source.DecodeFailed += failure;

--- a/src/source.extension.vsixmanifest
+++ b/src/source.extension.vsixmanifest
@@ -1,25 +1,25 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
-  <Metadata>
-    <Identity Id="1c63270f-485d-4810-99b8-e9d9de82610c" Version="1.1" Language="en-US" Publisher="Mads Kristensen" />
-    <DisplayName>CSS Tools 2019</DisplayName>
-    <Description xml:space="preserve">Provides additional features to the CSS editor in Visual Studio.</Description>
-    <MoreInfo>https://github.com/madskristensen/CssTools</MoreInfo>
-    <License>Resources\LICENSE</License>
-    <ReleaseNotes>https://github.com/madskristensen/CssTools/blob/master/CHANGELOG.md</ReleaseNotes>
-    <Icon>Resources\Icon.png</Icon>
-    <PreviewImage>Resources\Icon.png</PreviewImage>
-    <Tags>css, less, sass, scss, stylesheet</Tags>
-  </Metadata>
-  <Installation>
-    <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[16.0,17.0)" />
-  </Installation>
-  <Prerequisites>
-    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[16.0,)" DisplayName="Visual Studio core editor" />
-    <Prerequisite Id="Microsoft.VisualStudio.Component.Web" Version="[16.0,)" DisplayName="Web development tools" />
-  </Prerequisites>
-  <Assets>
-    <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
-    <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%|" />
-  </Assets>
+    <Metadata>
+        <Identity Id="1c63270f-485d-4810-99b8-e9d9de82610c" Version="1.1.3" Language="en-US" Publisher="Mads Kristensen" />
+        <DisplayName>CSS Tools 2019</DisplayName>
+        <Description xml:space="preserve">Provides additional features to the CSS editor in Visual Studio.</Description>
+        <MoreInfo>https://github.com/madskristensen/CssTools</MoreInfo>
+        <License>Resources\LICENSE</License>
+        <ReleaseNotes>https://github.com/madskristensen/CssTools/blob/master/CHANGELOG.md</ReleaseNotes>
+        <Icon>Resources\Icon.png</Icon>
+        <PreviewImage>Resources\Icon.png</PreviewImage>
+        <Tags>css, less, sass, scss, stylesheet</Tags>
+    </Metadata>
+    <Installation>
+        <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[16.0,17.0)" />
+    </Installation>
+    <Prerequisites>
+        <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[16.0,)" DisplayName="Visual Studio core editor" />
+        <Prerequisite Id="Microsoft.VisualStudio.Component.Web" Version="[16.0,)" DisplayName="Web development tools" />
+    </Prerequisites>
+    <Assets>
+        <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%;PkgdefProjectOutputGroup|" />
+        <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="%CurrentProject%" Path="|%CurrentProject%|" />
+    </Assets>
 </PackageManifest>


### PR DESCRIPTION
I created a fixed dimensions verison of no preview image which dimensions fixed to 150x150. At least that can solve UX issues for develepoment environment.